### PR TITLE
remove loans field from REVConfig

### DIFF
--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -229,8 +229,7 @@ contract DeployScript is Script, Sphinx {
                 baseCurrency: ETH_CURRENCY,
                 splitOperator: OPERATOR,
                 stageConfigurations: stageConfigurations,
-                loanSources: _loanSources,
-                loans: address(revnet.loans)
+                loanSources: _loanSources
             });
         }
 

--- a/src/Banny721TokenUriResolver.sol
+++ b/src/Banny721TokenUriResolver.sol
@@ -1120,6 +1120,8 @@ contract Banny721TokenUriResolver is
             }
 
             // Remove all previous assets up to and including the current category being iterated on.
+            // This inner loop advances through `previousOutfitIds` (bounded by outfit category count) and
+            // terminates when it passes the current category or exhausts the array.
             while (previousOutfitProductCategory <= outfitProductCategory && previousOutfitProductCategory != 0) {
                 // Transfer the previous outfit to the owner of the banny if its not being worn.
                 // `_attachedOutfitIdsOf` hasnt been called yet, so the wearer should still be the banny body being
@@ -1157,6 +1159,9 @@ contract Banny721TokenUriResolver is
         }
 
         // Remove and transfer out any remaining assets no longer being worn.
+        // This loop is bounded by `previousOutfitIds.length`, which equals the number of outfits previously
+        // attached to this banny. Since only one outfit per category is allowed, this is bounded by the number of
+        // outfit categories (a small, fixed set).
         while (previousOutfitId != 0) {
             // `_attachedOutfitIdsOf` hasnt been called yet, so the wearer should still be the banny body being
             // decorated.


### PR DESCRIPTION
REVDeployer now hardcodes the LOANS address in its constructor.

# Description

*What does this PR: do, how, why?*

## Limitations & risks

*Are there any trade-off or new vulnarbility surface based on theses changes?*

# Check-list
- [ ] Tests are covering the new feature
- [ ] Code is [natspec'd](https://docs.soliditylang.org/en/v0.8.17/natspec-format.html)
- [ ] Code is [linted and formatted](https://docs.soliditylang.org/en/v0.8.17/style-guide.html)
- [ ] I have run the test locally (and they pass)
- [ ] I have rebased to the latest main commit (and tests still pass)

# Interactions
These changes will impact the following contracts:
- Directly:

- Indirectly: