### PR TITLE
fix: align IBanny721TokenUriResolver.outfitLockedUntil argument name …

### DIFF
--- a/src/interfaces/IBanny721TokenUriResolver.sol
+++ b/src/interfaces/IBanny721TokenUriResolver.sol
@@ -16,7 +16,7 @@ interface IBanny721TokenUriResolver {
 
     function svgHashOf(uint256 upc) external view returns (bytes32);
     function svgBaseUri() external view returns (string memory);
-    function outfitLockedUntil(address hook, uint256 tokenId) external view returns (uint256);
+    function outfitLockedUntil(address hook, uint256 upc) external view returns (uint256);
     function DEFAULT_ALIEN_EYES() external view returns (string memory);
     function DEFAULT_MOUTH() external view returns (string memory);
     function DEFAULT_NECKLACE() external view returns (string memory);


### PR DESCRIPTION
…with implementation

Renames tokenId to upc to match the mapping key name in Banny721TokenUriResolver.sol.

# Description

*What does this PR: do, how, why?*

## Limitations & risks

*Are there any trade-off or new vulnarbility surface based on theses changes?*

# Check-list
- [ ] Tests are covering the new feature
- [ ] Code is [natspec'd](https://docs.soliditylang.org/en/v0.8.17/natspec-format.html)
- [ ] Code is [linted and formatted](https://docs.soliditylang.org/en/v0.8.17/style-guide.html)
- [ ] I have run the test locally (and they pass)
- [ ] I have rebased to the latest main commit (and tests still pass)

# Interactions
These changes will impact the following contracts:
- Directly:

- Indirectly: