### PR TITLE
Append V6 to deploy salts

### DIFF
--- a/script/1.Fix.s.sol
+++ b/script/1.Fix.s.sol
@@ -24,7 +24,7 @@ contract Drop1Script is Script, Sphinx {
 
     JB721TiersHook hook;
 
-    bytes32 RESOLVER_SALT = "_BAN_RESOLVER__";
+    bytes32 RESOLVER_SALT = "_BAN_RESOLVERV6__";
     address OPERATOR;
     address TRUSTED_FORWARDER;
 

--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -64,10 +64,10 @@ contract DeployScript is Script, Sphinx {
     BannyverseRevnetConfig bannyverseConfig;
 
     uint32 PREMINT_CHAIN_ID = 1;
-    bytes32 ERC20_SALT = "_BAN_ERC20_";
-    bytes32 SUCKER_SALT = "_BAN_SUCKER_";
-    bytes32 HOOK_SALT = "_BAN_HOOK_";
-    bytes32 RESOLVER_SALT = "_BAN_RESOLVER_";
+    bytes32 ERC20_SALT = "_BAN_ERC20V6_";
+    bytes32 SUCKER_SALT = "_BAN_SUCKERV6_";
+    bytes32 HOOK_SALT = "_BAN_HOOKV6_";
+    bytes32 RESOLVER_SALT = "_BAN_RESOLVERV6_";
     string NAME = "Banny Network";
     string SYMBOL = "BAN";
     string PROJECT_URI = "ipfs://Qme34ww9HuwnsWF6sYDpDfpSdYHpPCGsEyJULk1BikCVYp";


### PR DESCRIPTION
## Summary
- Updated `ERC20_SALT`, `SUCKER_SALT`, `HOOK_SALT`, `RESOLVER_SALT` with V6 suffix in `Deploy.s.sol`
- Updated `RESOLVER_SALT` with V6 suffix in `1.Fix.s.sol`

Ensures all V6 contracts deploy to different deterministic addresses than V5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)